### PR TITLE
Add node-canvas to help increase the testable surface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,20 @@ os:
 node_js:
   - 6
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq install g++-4.8 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-4.8 ; fi
   - npm install -g npm@5.1.0
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libcairo2-dev
+      - libjpeg8-dev
+      - libpango1.0-dev
+      - libgif-dev
+      - g++-4.9
 env:
+  global:
+    - CXX=g++-4.9
   matrix:
     - NPM_COMMAND=tsc
     - NPM_COMMAND=lint

--- a/README.md
+++ b/README.md
@@ -178,7 +178,19 @@ Then open http://0.0.0.0:3000 in a web browser to access the demo.
 
 ### Linux or macOS
 
-First, be sure that a C++ compiler such as GCC-C++ or Clang is installed, then run the following commands in your terminal:
+First, be sure that a C++ compiler such as GCC-C++ or Clang is installed.
+
+Then, depending on your operating system and distribution, run one of the following:
+
+OS | Command
+----- | -----
+OS X | Using [Homebrew](https://brew.sh/):<br/>`brew install pkg-config cairo pango libpng jpeg giflib`<br/><br/>Using [MacPorts](https://www.macports.org/):<br/>`port install pkgconfig cairo pango libpng jpeg giflib`
+Ubuntu | `sudo apt-get install libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev build-essential g++`
+Fedora | `sudo yum install cairo cairo-devel cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel giflib-devel`
+
+*This table is borrowed from [the node-canvas documentation](https://github.com/Automattic/node-canvas/blob/master/Readme.md#compiling).*
+
+Then run the following commands in your terminal:
 
 ```
 npm install
@@ -190,7 +202,7 @@ Then open http://0.0.0.0:3000 in a web browser to access the demo.
 
 ### Windows
 
-First, ensure [node-gyp](https://github.com/nodejs/node-gyp) is installed and configured correctly, then run the following commands in your terminal:
+First, [follow the node-canvas setup instructions](https://github.com/Automattic/node-canvas/wiki/Installation---Windows), then run the following commands in your terminal:
 
 ```
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -714,6 +714,15 @@
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true
     },
+    "canvas": {
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-1.6.10.tgz",
+      "integrity": "sha512-wd97ZrUfLYWjQ0qcJGiM44anXB+RviRu3DETpPIS4Sf7JzhP9PawwHdZOlx8sufcsRSeWuQe93qaCtwvK1jWXQ==",
+      "dev": true,
+      "requires": {
+        "nan": "2.8.0"
+      }
+    },
     "caseless": {
       "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
@@ -2536,8 +2545,7 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "json-schema": {
           "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/node": "^6.0.41",
     "@types/text-encoding": "0.0.32",
     "browserify": "^13.3.0",
+    "canvas": "^1.6.10",
     "chai": "3.5.0",
     "docdash": "0.4.0",
     "express": "4.13.4",

--- a/src/renderer/ColorManager.test.ts
+++ b/src/renderer/ColorManager.test.ts
@@ -17,17 +17,6 @@ describe('ColorManager', () => {
     dom = new jsdom.JSDOM('');
     window = dom.window;
     document = window.document;
-    (<any>window).HTMLCanvasElement.prototype.getContext = () => ({
-      createLinearGradient(): any {
-        return null;
-      },
-
-      fillRect(): void { },
-
-      getImageData(): any {
-        return {data: [0, 0, 0, 0]};
-      }
-    });
     cm = new ColorManager(document);
   });
 
@@ -308,6 +297,18 @@ describe('ColorManager', () => {
       assert.equal(cm.colors.background.css, '#0000FF');
       // FG reverts back to default
       assert.equal(cm.colors.foreground.css, '#ffffff');
+    });
+
+    it('should parse rgb colors', () => {
+      cm.setTheme({
+        background: '#123456',
+        foreground: 'rgb(111, 222, 33)',
+      });
+      assert.equal(cm.colors.background.rgba, 0x123456FF);
+      assert.equal(cm.colors.foreground.rgba >>> 24, 111);
+      assert.equal(cm.colors.foreground.rgba >>> 16 & 0xFF, 222);
+      assert.equal(cm.colors.foreground.rgba >>> 8 & 0xFF, 33);
+      assert.equal(cm.colors.foreground.rgba & 0xFF, 0xFF);
     });
   });
 });


### PR DESCRIPTION
This is at least a first step towards fixing #1247. This adds some complexity to the initial setup, since canvas needs to be built from source.

This won't be true once canvas 2.x is stabilized, because that version downloads (Automattic/node-canvas#992). JSDom doesn't support 2.x, and doesn't until a stable release is cut.

We could use [canvas-prebuilt](https://github.com/node-gfx/node-canvas-prebuilt), which JSDom does appear to support. However, I'm not sure if that would cause pain for people with 32-bit operating systems (see the compatibility table on that page).

I'm not sure if this travis configuration will work; I'll iterate on it in the PR if it fails. I removed a bunch of hacks that were added in #690, since they don't look necessary anymore (the sleep module is gone).