### PR TITLE
Block transparent colors without allowTransparency

### DIFF
--- a/src/renderer/ColorManager.test.ts
+++ b/src/renderer/ColorManager.test.ts
@@ -25,10 +25,10 @@ describe('ColorManager', () => {
       fillRect(): void { },
 
       getImageData(): any {
-        return {data: [0, 0, 0, 0]};
+        return {data: [0, 0, 0, 0xFF]};
       }
     });
-    cm = new ColorManager(document);
+    cm = new ColorManager(document, false);
   });
 
   describe('constructor', () => {

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -29,13 +29,14 @@ export class Renderer extends EventEmitter implements IRenderer {
 
   constructor(private _terminal: ITerminal, theme: ITheme) {
     super();
-    this.colorManager = new ColorManager(document);
+    const allowTransparency = this._terminal.options.allowTransparency;
+    this.colorManager = new ColorManager(document, allowTransparency);
     if (theme) {
       this.colorManager.setTheme(theme);
     }
 
     this._renderLayers = [
-      new TextRenderLayer(this._terminal.screenElement, 0, this.colorManager.colors, this._terminal.options.allowTransparency),
+      new TextRenderLayer(this._terminal.screenElement, 0, this.colorManager.colors, allowTransparency),
       new SelectionRenderLayer(this._terminal.screenElement, 1, this.colorManager.colors),
       new LinkRenderLayer(this._terminal.screenElement, 2, this.colorManager.colors, this._terminal),
       new CursorRenderLayer(this._terminal.screenElement, 3, this.colorManager.colors)


### PR DESCRIPTION
Fixes xtermjs/xterm.js#1357.

cc @Tyriar

![](https://user-images.githubusercontent.com/180404/38075407-1bbbfab6-32e7-11e8-9e86-5e5c08c5245c.png)

I could probably add a test with some more mocking, but I'd rather try to get the `node-canvas` stuff in bgw/xterm.js#1 landed.